### PR TITLE
Add RestoreItemlinkInColorAnnounce patch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->
+* **Description of Pull Request**:
+
+* **Addressed Issue(s)**: 
+<!-- If this PR fixes or relates to an existing issue, paste the URL here. -->
+<!-- Example: https://github.com/CrazyBebop/WARP0716/issues/123 -->
+
+* **Features**:
+<!-- List the key features, improvements, or fixes introduced by this PR. -->

--- a/Patches/Data.yml
+++ b/Patches/Data.yml
@@ -468,3 +468,9 @@ MultiGRFs:
             recommend : no
             author : Neo-Mind
             desc : Embeds GRF filenames directly into the client executable instead of reading from an external INI file. You provide the GRF list at patch time and it gets baked into the exe. No DATA.INI file needed in the client folder.
+
+        - RestoreItemlinkInColorAnnounce:
+            title : $$ Fix item links in colored announce
+            recommend : no
+            author : kikyamyam
+            desc : Restores clickable item links when using announce with custom color (announce type 0x1C3).

--- a/Scripts/Patches/RestoreItemLinkColorAnnounce.qjs
+++ b/Scripts/Patches/RestoreItemLinkColorAnnounce.qjs
@@ -1,0 +1,22 @@
+// Author: kikyamyam
+// Restores item link in color announce
+
+function Hex(str) {
+    return str.trim().split(/\s+/).map(h => parseInt(h, 16));
+}
+
+RestoreItemlinkInColorAnnounce = function(_) {
+    let addr;
+
+    // Patch #1
+    addr = Exe.FindHex("0F 84 87 00 00 00 8B 95 EC FD FF FF 83 FA 10 72 31");
+    if (addr < 0) throw new Error("Failed to find pattern #1.");
+    Exe.SetBytes(addr, Hex("E9 88 00 00 00 00 8B 95 EC FD FF FF 83 FA 10 72 31"));
+
+    // Patch #2
+    addr = Exe.FindHex("C6 45 FC 02 8D 8D C0 FD FF FF E8 D1 8F 83 FF 8D 85 BC FD FF FF 50 8D 85 D8 FD FF FF 50 8D 8D 88");
+    if (addr < 0) throw new Error("Failed to find pattern #2.");
+    Exe.SetBytes(addr, Hex("90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 8D 85 BC FD FF FF 50 8D 85 C0 FD FF FF 50 8D 8D 88"));
+
+    return true;
+}

--- a/Tables/Patch.yml
+++ b/Tables/Patch.yml
@@ -294,3 +294,5 @@
 356 : SendClientFlags
 357 : RestoreCpsDll
 358 : CustomMissingLauncherMsg
+
+1000: RestoreItemlinkInColorAnnounce


### PR DESCRIPTION
Restores clickable item links when using announce with custom color (announce type 0x1C3).

Before:
<img width="215" height="36" alt="image" src="https://github.com/user-attachments/assets/04723480-2626-4777-a79c-ce56bb634e84" />

After:
<img width="197" height="36" alt="image" src="https://github.com/user-attachments/assets/65bb17ed-b34c-4c45-95e6-f524d2e0e697" />

