### PR TITLE
Disable Equipment Attribute Button patch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->
+* **Description of Pull Request**:
+
+* **Addressed Issue(s)**: 
+<!-- If this PR fixes or relates to an existing issue, paste the URL here. -->
+<!-- Example: https://github.com/CrazyBebop/WARP0716/issues/123 -->
+
+* **Features**:
+<!-- List the key features, improvements, or fixes introduced by this PR. -->

--- a/DisableEquipmentAttribute.diff
+++ b/DisableEquipmentAttribute.diff
@@ -1,0 +1,80 @@
+diff --git a/Patches/Window.yml b/Patches/Window.yml
+index 007a686..8252113 100644
+--- a/Patches/Window.yml
++++ b/Patches/Window.yml
+@@ -124,6 +124,12 @@ CustomEquipWin:
+             author : CH.C (jchcc), Andrei Karas (4144) , X-EcutiOnner
+             desc : Removes the title bar text from the equipment window. A cosmetic change for a cleaner equipment window appearance.
+ 
++        - DisableEquipAttrButton:
++            title : Disable Equipment Attribute Button
++            recommend : no
++            author : Gerzzie (RDL)
++            desc : Disables the Equipment Attribute (Properties) button in the Equipment Window so clicking it does nothing. Use on servers where the Equipment Properties panel is not applicable.
++
+ CustomExpBars:
+     title : EXP BAR CUSTOMIZATION
+     mutex : false
+diff --git a/Scripts/Patches/CustomEquipWin.qjs b/Scripts/Patches/CustomEquipWin.qjs
+index ee7fd20..ee79628 100644
+--- a/Scripts/Patches/CustomEquipWin.qjs
++++ b/Scripts/Patches/CustomEquipWin.qjs
+@@ -237,3 +237,58 @@ NoEquipWinTitle.validate = function()
+ 	if (Exe.BuildDate >= 20240000) return true;
+ 	return (ROC.IsRenewal && Exe.BuildDate >= 20141126) || Exe.BuildDate >= 20150225;
+ };
++
++///
++/// \brief Hides the Equipment Attribute button from the Equipment Window by
++///        skipping the button creation entirely. The button will not appear.
++///
++DisableEquipAttrButton = function(_)
++{
++	$$(_, 1, `Find the Equipment Attribute button bitmap string`);
++	const bmpVA = Exe.FindText(
++		"\xC0\xAF\xC0\xFA\xC0\xCE\xC5\xCD\xC6\xE4\xC0\xCC\xBD\xBA\\basic_interface\\btn_e_ability_a.bmp"
++	);
++	if (bmpVA < 0)
++		throw Error("btn_e_ability_a.bmp string not found");
++
++	$$(_, 2, `Find PUSH of the bitmap string in code`);
++	const pushAddr = Exe.FindHex(PUSH(bmpVA));
++	if (pushAddr < 0)
++		throw Error("PUSH btn_e_ability_a not found in code");
++
++	$$(_, 3, `Find the guard conditional jump before button creation`);
++
++	// Search backward from the PUSH for TEST EAX, EAX + JNZ near
++	// which guards the entire button creation block
++	let addr = Exe.FindHex(TEST(EAX, EAX) + JNZ(POS3WC), pushAddr - 0x60, pushAddr);
++	if (addr < 0)
++		addr = Exe.FindHex(TEST(EAX, EAX) + JNE(POS3WC), pushAddr - 0x60, pushAddr);
++
++	if (addr >= 0)
++	{
++		$$(_, 4, `Convert JNZ to JMP to skip button creation`);
++		Exe.SetJMP(addr + TEST(EAX, EAX).byteCount());
++		return true;
++	}
++
++	// Fallback: look for CMP + JNZ pattern instead
++	addr = Exe.FindHex(CMP(EAX, 0) + JNZ(POS3WC), pushAddr - 0x60, pushAddr);
++	if (addr >= 0)
++	{
++		$$(_, 4, `Convert JNZ to JMP to skip button creation`);
++		Exe.SetJMP(addr + CMP(EAX, 0).byteCount());
++		return true;
++	}
++
++	throw Error("Guard jump before button creation not found");
++};
++
++///
++/// \brief Disable for unsupported clients - need the Equipment Attribute button bitmap
++///
++DisableEquipAttrButton.validate = function()
++{
++	return Exe.FindText(
++		"\xC0\xAF\xC0\xFA\xC0\xCE\xC5\xCD\xC6\xE4\xC0\xCC\xBD\xBA\\basic_interface\\btn_e_ability_a.bmp"
++	) > 0;
++};

--- a/Patches/Window.yml
+++ b/Patches/Window.yml
@@ -124,6 +124,12 @@ CustomEquipWin:
             author : CH.C (jchcc), Andrei Karas (4144) , X-EcutiOnner
             desc : Removes the title bar text from the equipment window. A cosmetic change for a cleaner equipment window appearance.
 
+        - DisableEquipAttrButton:
+            title : Disable Equipment Attribute Button
+            recommend : no
+            author : Gerzzie (RDL)
+            desc : Disables the Equipment Attribute (Properties) button in the Equipment Window so clicking it does nothing. Use on servers where the Equipment Properties panel is not applicable.
+
 CustomExpBars:
     title : EXP BAR CUSTOMIZATION
     mutex : false

--- a/Scripts/Patches/CustomEquipWin.qjs
+++ b/Scripts/Patches/CustomEquipWin.qjs
@@ -256,31 +256,70 @@ DisableEquipAttrButton = function(_)
 	if (pushAddr < 0)
 		throw Error("PUSH btn_e_ability_a not found in code");
 
-	$$(_, 3, `Find the guard conditional jump before button creation`);
+	$$(_, 3, `Find button UUID PUSH near bitmap reference`);
+	const winStart = Math.max(pushAddr - 0x50, 0);
+	const winEnd = pushAddr + 0x90;
+	let idPushAddr = -1;
+	let idValue = -1;
 
-	// Search backward from the PUSH for TEST EAX, EAX + JNZ near
-	// which guards the entire button creation block
-	let addr = Exe.FindHex(TEST(EAX, EAX) + JNZ(POS3WC), pushAddr - 0x60, pushAddr);
-	if (addr < 0)
-		addr = Exe.FindHex(TEST(EAX, EAX) + JNE(POS3WC), pushAddr - 0x60, pushAddr);
-
-	if (addr >= 0)
+	// Prefer a nearby PUSH imm32 that is actually used in click-dispatch compares.
+	for (let a = winStart; a <= winEnd; ++a)
 	{
-		$$(_, 4, `Convert JNZ to JMP to skip button creation`);
-		Exe.SetJMP(addr + TEST(EAX, EAX).byteCount());
-		return true;
+		if (Exe.GetUint8(a) != 0x68) continue; // PUSH imm32
+		const v = Exe.GetInt32(a + 1);
+		if (v < 0x100 || v > 0x1000) continue;
+
+		const hasDispatchCmp =
+			Exe.FindHex(CMP(EAX, v) + JG(POS3WC) + JZ(POS3WC)) >= 0 ||
+			Exe.FindHex(CMP(EAX, v) + JNE(POS3WC) + JZ(POS3WC)) >= 0 ||
+			Exe.FindHex(CMP(EAX, v) + JA(POS3WC) + JE(POS3WC)) >= 0;
+		if (!hasDispatchCmp) continue;
+
+		idPushAddr = a;
+		idValue = v;
+		break;
 	}
 
-	// Fallback: look for CMP + JNZ pattern instead
-	addr = Exe.FindHex(CMP(EAX, 0) + JNZ(POS3WC), pushAddr - 0x60, pushAddr);
-	if (addr >= 0)
+	// Fallback: first plausible UUID PUSH after the bitmap reference.
+	if (idPushAddr < 0)
 	{
-		$$(_, 4, `Convert JNZ to JMP to skip button creation`);
-		Exe.SetJMP(addr + CMP(EAX, 0).byteCount());
-		return true;
+		for (let a = pushAddr; a <= winEnd; ++a)
+		{
+			if (Exe.GetUint8(a) != 0x68) continue;
+			const v = Exe.GetInt32(a + 1);
+			if (v < 0x100 || v > 0x1000) continue;
+			idPushAddr = a;
+			idValue = v;
+			break;
+		}
 	}
 
-	throw Error("Guard jump before button creation not found");
+	if (idPushAddr < 0)
+		throw Error("Equipment Attribute button UUID PUSH not found");
+
+	$$(_, 4, `Rewrite button UUID ${idValue.toHex()} to an unused value`);
+	Exe.SetUint32(idPushAddr + 1, 0x7FFF);
+	$$(_, 5, `Try to hide visual button via validated AddChild call only`);
+
+	const addChildPrefix =
+		PUSH([R32, POS2WC]) // push button/control pointer
+	+	MOV(ECX, R32)       // this = parent window
+	;
+	const addChildSig = addChildPrefix + CALL(ALLWC);
+	const addChildPos = Exe.FindHex(addChildSig, idPushAddr, idPushAddr + 0x90);
+
+	if (addChildPos >= 0)
+	{
+		const addChildCall = addChildPos + addChildPrefix.byteCount();
+		// Keep stack balanced for skipped AddChild(button).
+		Exe.SetHex(addChildCall, ADD(ESP, 4) + NOP2);
+	}
+	else
+	{
+		$$(_, 5.1, `validated AddChild pattern not found, keeping UUID-only disable`);
+	}
+
+	return true;
 };
 
 ///

--- a/Scripts/Patches/CustomEquipWin.qjs
+++ b/Scripts/Patches/CustomEquipWin.qjs
@@ -237,3 +237,58 @@ NoEquipWinTitle.validate = function()
 	if (Exe.BuildDate >= 20240000) return true;
 	return (ROC.IsRenewal && Exe.BuildDate >= 20141126) || Exe.BuildDate >= 20150225;
 };
+
+///
+/// \brief Hides the Equipment Attribute button from the Equipment Window by
+///        skipping the button creation entirely. The button will not appear.
+///
+DisableEquipAttrButton = function(_)
+{
+	$$(_, 1, `Find the Equipment Attribute button bitmap string`);
+	const bmpVA = Exe.FindText(
+		"\xC0\xAF\xC0\xFA\xC0\xCE\xC5\xCD\xC6\xE4\xC0\xCC\xBD\xBA\\basic_interface\\btn_e_ability_a.bmp"
+	);
+	if (bmpVA < 0)
+		throw Error("btn_e_ability_a.bmp string not found");
+
+	$$(_, 2, `Find PUSH of the bitmap string in code`);
+	const pushAddr = Exe.FindHex(PUSH(bmpVA));
+	if (pushAddr < 0)
+		throw Error("PUSH btn_e_ability_a not found in code");
+
+	$$(_, 3, `Find the guard conditional jump before button creation`);
+
+	// Search backward from the PUSH for TEST EAX, EAX + JNZ near
+	// which guards the entire button creation block
+	let addr = Exe.FindHex(TEST(EAX, EAX) + JNZ(POS3WC), pushAddr - 0x60, pushAddr);
+	if (addr < 0)
+		addr = Exe.FindHex(TEST(EAX, EAX) + JNE(POS3WC), pushAddr - 0x60, pushAddr);
+
+	if (addr >= 0)
+	{
+		$$(_, 4, `Convert JNZ to JMP to skip button creation`);
+		Exe.SetJMP(addr + TEST(EAX, EAX).byteCount());
+		return true;
+	}
+
+	// Fallback: look for CMP + JNZ pattern instead
+	addr = Exe.FindHex(CMP(EAX, 0) + JNZ(POS3WC), pushAddr - 0x60, pushAddr);
+	if (addr >= 0)
+	{
+		$$(_, 4, `Convert JNZ to JMP to skip button creation`);
+		Exe.SetJMP(addr + CMP(EAX, 0).byteCount());
+		return true;
+	}
+
+	throw Error("Guard jump before button creation not found");
+};
+
+///
+/// \brief Disable for unsupported clients - need the Equipment Attribute button bitmap
+///
+DisableEquipAttrButton.validate = function()
+{
+	return Exe.FindText(
+		"\xC0\xAF\xC0\xFA\xC0\xCE\xC5\xCD\xC6\xE4\xC0\xCC\xBD\xBA\\basic_interface\\btn_e_ability_a.bmp"
+	) > 0;
+};


### PR DESCRIPTION
This has the Equipment Attribute Button right next to the Swap Equipment Button.
<img width="278" height="188" alt="image" src="https://github.com/user-attachments/assets/2051d74f-6424-423e-b721-c128898e5ff4" />

After applying the patch.
<img width="280" height="187" alt="image" src="https://github.com/user-attachments/assets/25af52c9-0a3c-4414-92e5-3dd6103f382d" />

