### PR TITLE
Add ChatBgOpacity patch: make chat window background opaque or custom

### DIFF
--- a/Patches/UI.yml
+++ b/Patches/UI.yml
@@ -194,6 +194,18 @@ CustomUI:
             author : Andrei Karas (4144)
             desc : Restores keyboard input focus to the chat box after clicking with the left mouse button. Fixes the issue where clicking in the game world causes the chat input to lose focus.
 
+        - OpaqueChatBg:
+            title : Make chat window background opaque
+            recommend : no
+            author : Stingor
+            desc : Removes the semi-transparency from the chat window background. By default the background is drawn at 40% alpha (0x66), letting the game world show through. This patch forces it to 100% opaque (0xFF), producing a solid black background.
+
+        - CustomChatBgOpacity:
+            title : Customize chat window background color and opacity
+            recommend : no
+            author : Stingor
+            desc : Changes the color and transparency of the chat window background. Opens a color picker (RGB) and a separate opacity slider (0 = fully transparent, 255 = fully opaque). The default background is pure black at 40% opacity (0x66).
+
         - NoEquipPreview:
             title : Disable equipment preview
             recommend : no

--- a/Scripts/Patches/ChatBgOpacity.qjs
+++ b/Scripts/Patches/ChatBgOpacity.qjs
@@ -1,0 +1,101 @@
+/**************************************************************************\
+*                                                                          *
+*   Copyright (C) 2026                                                     *
+*                                                                          *
+*   This file is a part of WARP project (specific to RO clients)           *
+*                                                                          *
+*   WARP is free software: you can redistribute it and/or modify           *
+*   it under the terms of the GNU General Public License as published by   *
+*   the Free Software Foundation, either version 3 of the License, or      *
+*   (at your option) any later version.                                    *
+*                                                                          *
+*   This program is distributed in the hope that it will be useful,        *
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+*   GNU General Public License for more details.                           *
+*                                                                          *
+*   You should have received a copy of the GNU General Public License      *
+*   along with this program.  If not, see <http://www.gnu.org/licenses/>.  *
+*                                                                          *
+*                                                                          *
+|**************************************************************************|
+*                                                                          *
+*   Author(s)     : Stingor, Claude Sonnet                                 *
+*   Created Date  : 2026-06-13                                             *
+*   Last Modified : 2026-06-13                                             *
+*                                                                          *
+\**************************************************************************/
+
+///
+/// \brief Patches the ARGB color constant used for the chat window background.
+///
+///        The chat window initialization stores 0x66000000 (ARGB: A=40%,
+///        R=0, G=0, B=0) at this+0xD8.  The renderer multiplies the white
+///        background tile (sysbox_bg.bmp) by this color, producing a
+///        semi-transparent dark overlay.
+///
+///        OpaqueChatBg        - Forces fully opaque black (A=0xFF, RGB=black).
+///        CustomChatBgOpacity - Lets the user choose any RGB color and alpha.
+///
+ChatBgOpacity = function(_)
+{
+	$$(_, 1.1, `Find the chat window background ARGB color initialization`)
+	// MOV dword ptr [reg+0D8h], 66000000h
+	// Pattern: C7 <ModRM> D8 00 00 00 | 00 00 00 66
+	//          ^^^^^^^^^^^^^^^^^^^^^^^^  ^---------^
+	//          field offset 0xD8          ARGB value (little-endian: B G R A)
+	// The 4-byte ARGB value starts at pattern offset +6.
+	const addr = Exe.FindHex("C7 ?? D8 00 00 00 00 00 00 66");
+	if (addr < 0)
+		throw Error("Chat background color pattern not found");
+
+	const ARGB_OFF = 6; // offset of the 4-byte ARGB value within the pattern
+
+	if (_ === "OpaqueChatBg")
+	{
+		$$(_, 2.1, `Set to fully opaque black: ARGB = 0xFF000000`)
+		// Little-endian byte order: B=00 G=00 R=00 A=FF
+		Exe.SetHex(addr + ARGB_OFF, "00 00 00 FF");
+	}
+	else
+	{
+		$$(_, 2.1, `Get the desired opacity (alpha) from the user`)
+		const alphaVar = "$chatBgAlpha";
+		const alpha = Exe.GetUserInput(
+			alphaVar, D_Uint8,
+			"Chat Background Opacity",
+			"Enter opacity (0 = fully transparent, 255 = fully opaque)",
+			0xFF,
+			{ min: 0, max: 255 }
+		);
+		if (alpha === false)
+			Cancel("Opacity", 255);
+
+		$$(_, 2.2, `Get the desired RGB color from the user`)
+		const colorVar = "$chatBgColor";
+		const color = Exe.GetUserInput(
+			colorVar, D_Color,
+			"Chat Background Color",
+			"Select the background color",
+			0x000000,
+			ROC.ClrSettings
+		);
+		if (color === false)
+			Cancel("Color", "#000000");
+
+		$$(_, 2.3, `Combine alpha + RGB and write as little-endian ARGB DWORD`)
+		// D_Color returns 0xRRGGBB; memory layout for ARGB little-endian is B G R A
+		const r = (color >> 16) & 0xFF;
+		const g = (color >>  8) & 0xFF;
+		const b =  color        & 0xFF;
+		const hx = [b, g, r, alpha]
+			.map(v => v.toString(16).toUpperCase().padStart(2, "0"))
+			.join(" ");
+		Exe.SetHex(addr + ARGB_OFF, hx);
+	}
+
+	return true;
+};
+
+OpaqueChatBg        = ChatBgOpacity;
+CustomChatBgOpacity = ChatBgOpacity;


### PR DESCRIPTION
The floating chat window uses a hardcoded ARGB color 0x66000000 (pure black at 40% opacity) stored at this+0xD8 during initialization. The white sysbox_bg.bmp tile is multiplied by this color at render time, producing the characteristic semi-transparent dark overlay.

Two patch variants:
  - OpaqueChatBg: one-click, forces fully opaque black (0xFF000000)
  - CustomChatBgOpacity: opens a color picker (RGB) + opacity slider (0-255) so users can set any background color and transparency level

Pattern searched: C7 ?? D8 00 00 00 00 00 00 66
Verified unique on 2025-07-16 ragexe (single hit, file 0x4E99B5).

I am very happy to share, hope it get ported to other Exe version !!

I used cheat engine to provide context to Claude and Ghidra MCP server