### PR TITLE
Update main chat bg patch and Add detached/whisper chat bg patches

### DIFF
--- a/Patches/UI.yml
+++ b/Patches/UI.yml
@@ -121,7 +121,13 @@ CustomUI:
             recommend : no
             author : 4144,Skylove
             desc : Raises the maximum number of items that can be added through cash inventory expansion from the default 100 up to 999,999. Server-side adjustment may be required to match.
-            
+
+        - BiggerInventoryWindow:
+            title : Bigger inventory window
+            recommend : no
+            author : Stingor
+            desc : Raises the maximum size the inventory window can be resized to. The stock client clamps the drag-resize to 320x240; this lets you set a larger maximum (default 1280x1024) so you can drag the inventory much bigger and see many more item slots at once. The window background is tiled, so it renders correctly at any size. This changes only the window SIZE, not the item CAPACITY (use 'Custom inventory limit' for that).
+
         - DeleteCharWithEmail:
             title : Always use email for Char Deletion
             recommend : no

--- a/Patches/UI.yml
+++ b/Patches/UI.yml
@@ -194,17 +194,23 @@ CustomUI:
             author : Andrei Karas (4144)
             desc : Restores keyboard input focus to the chat box after clicking with the left mouse button. Fixes the issue where clicking in the game world causes the chat input to lose focus.
 
-        - OpaqueChatBg:
-            title : Make chat window background opaque
+        - ChatBgMainPanel:
+            title : Customize main chat panel background color and opacity
             recommend : no
             author : Stingor
-            desc : Removes the semi-transparency from the chat window background. By default the background is drawn at 40% alpha (0x66), letting the game world show through. This patch forces it to 100% opaque (0xFF), producing a solid black background.
+            desc : Sets the color and opacity of the MAIN chat panel - its background and its active tab. Opens an RGB color picker and an opacity value (0 = transparent, 255 = opaque). Default is black at 40% opacity (0x66).
 
-        - CustomChatBgOpacity:
-            title : Customize chat window background color and opacity
+        - ChatBgDetached:
+            title : Customize detached chat windows background color and opacity
             recommend : no
             author : Stingor
-            desc : Changes the color and transparency of the chat window background. Opens a color picker (RGB) and a separate opacity slider (0 = fully transparent, 255 = fully opaque). The default background is pure black at 40% opacity (0x66).
+            desc : Sets the color and opacity of the DETACHED chat windows - their outer border/frame and background. Opens an RGB color picker and an opacity value (0 = transparent, 255 = opaque). Default is black at 40% opacity (0x66).
+
+        - ChatBgWhisper:
+            title : Customize whisper (1:1) chat window background color and opacity
+            recommend : no
+            author : Stingor
+            desc : "Sets the color and opacity of the 1:1 whisper (private message) chat window background. Opens an RGB color picker and an opacity value (0 = transparent, 255 = opaque). Leave a field unchanged to keep its default. Default is black at 40% opacity (0x66)."
 
         - NoEquipPreview:
             title : Disable equipment preview

--- a/Scripts/Patches/BiggerInventoryWindow.qjs
+++ b/Scripts/Patches/BiggerInventoryWindow.qjs
@@ -1,0 +1,61 @@
+/**************************************************************************\
+*                                                                          *
+*   Copyright (C) 2026                                                     *
+*                                                                          *
+*   This file is a part of WARP project (specific to RO clients)           *
+*                                                                          *
+*   WARP is free software: you can redistribute it and/or modify           *
+*   it under the terms of the GNU General Public License as published by   *
+*   the Free Software Foundation, either version 3 of the License, or      *
+*   (at your option) any later version.                                    *
+*                                                                          *
+|**************************************************************************|
+*                                                                          *
+*   Author(s)     : Stingor empowered by Claude                            *
+*   Created Date  : 2026-06-27                                             *
+*   Last Modified : 2026-06-27                                             *
+*                                                                          *
+\**************************************************************************/
+
+///
+/// \brief Raises the inventory window's user-resize maximum.
+///
+///        The inventory window's resize handler clamps the size the player can
+///        drag it to. Stock max is 320 x 240 (the two immediates MOV EDI,0x140
+///        and MOV EDX,0xF0 in the resize message handler). This patch rewrites
+///        those two immediates with user-chosen values, so the window can be
+///        dragged much larger and show many more item slots at once.
+///
+///        The inventory background is drawn as tiles (not a fixed bitmap), so it
+///        renders correctly at any size. The minimum size is untouched.
+///
+///        Note: this only changes the WINDOW size, not the item CAPACITY. Use
+///        "Custom inventory limit" to change how many items the bag can hold.
+///
+BiggerInventoryWindow = function(_)
+{
+	$$(_, 1, `Find the inventory resize clamp (MOV EDI,0x140 ... MOV EDX,0xF0)`)
+	// MOV EDI,140h | LEA EBX,[ESI+18h] | CMP [EBP+14h],EDI | MOV EDX,0F0h | MOV EAX,0E8h
+	// (the CMPs reuse EDI/EDX, so only the two MOV immediates set the max W/H)
+	const addr = Exe.FindHex("BF 40 01 00 00 8D 5E 18 39 7D 14 BA F0 00 00 00 B8 E8 00 00 00");
+	if (addr < 0)
+		throw Error("Inventory resize clamp pattern not found");
+
+	$$(_, 2.1, `Ask for the new maximum width`)
+	const wIn = Exe.GetUserInput('$InvWinMaxW', D_Uint32, "Inventory Window Max Width",
+		"Maximum width (in pixels) the inventory window can be resized to.\nStock = 320.",
+		1280, {min: 320, max: 2048});
+	const w = (typeof wIn === 'number') ? wIn : 1280; // keep default if left unchanged/cancelled
+
+	$$(_, 2.2, `Ask for the new maximum height`)
+	const hIn = Exe.GetUserInput('$InvWinMaxH', D_Uint32, "Inventory Window Max Height",
+		"Maximum height (in pixels) the inventory window can be resized to.\nStock = 240.",
+		1024, {min: 240, max: 2048});
+	const h = (typeof hIn === 'number') ? hIn : 1024;
+
+	$$(_, 3, `Patch the two clamp immediates`)
+	Exe.SetInt32(addr +  1, w); // MOV EDI,<maxWidth>
+	Exe.SetInt32(addr + 12, h); // MOV EDX,<maxHeight>
+
+	return true;
+};

--- a/Scripts/Patches/ChatBgOpacity.qjs
+++ b/Scripts/Patches/ChatBgOpacity.qjs
@@ -9,93 +9,158 @@
 *   the Free Software Foundation, either version 3 of the License, or      *
 *   (at your option) any later version.                                    *
 *                                                                          *
-*   This program is distributed in the hope that it will be useful,        *
-*   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
-*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
-*   GNU General Public License for more details.                           *
-*                                                                          *
-*   You should have received a copy of the GNU General Public License      *
-*   along with this program.  If not, see <http://www.gnu.org/licenses/>.  *
-*                                                                          *
-*                                                                          *
 |**************************************************************************|
 *                                                                          *
-*   Author(s)     : Stingor, Claude Sonnet                                 *
+*   Author(s)     : Stingor empowered by Claude                            *
 *   Created Date  : 2026-06-13                                             *
-*   Last Modified : 2026-06-13                                             *
+*   Last Modified : 2026-06-22                                             *
 *                                                                          *
 \**************************************************************************/
 
 ///
-/// \brief Patches the ARGB color constant used for the chat window background.
+/// \brief Recolours the chat window background, split into 3 patches.
 ///
-///        The chat window initialization stores 0x66000000 (ARGB: A=40%,
-///        R=0, G=0, B=0) at this+0xD8.  The renderer multiplies the white
-///        background tile (sysbox_bg.bmp) by this color, producing a
-///        semi-transparent dark overlay.
+///        By default the chat background is drawn as 40% black (semi-transparent),
+///        letting the game world show through. These patches let you pick any
+///        colour and opacity instead.
 ///
-///        OpaqueChatBg        - Forces fully opaque black (A=0xFF, RGB=black).
-///        CustomChatBgOpacity - Lets the user choose any RGB color and alpha.
+///        ChatBgMainPanel - the main chat window: its background and its active tab.
+///        ChatBgDetached  - the detached chat windows: their border and background.
+///        ChatBgWhisper   - the 1:1 whisper (private message) window background.
 ///
-ChatBgOpacity = function(_)
+///        Each patch asks for an opacity (0 = transparent, 255 = opaque) and a
+///        colour. Leave a value unchanged to keep its default.
+///
+
+//=========================================================================
+// Main chat window
+//=========================================================================
+ChatBgMainPanel = function(_)
 {
-	$$(_, 1.1, `Find the chat window background ARGB color initialization`)
-	// MOV dword ptr [reg+0D8h], 66000000h
-	// Pattern: C7 <ModRM> D8 00 00 00 | 00 00 00 66
-	//          ^^^^^^^^^^^^^^^^^^^^^^^^  ^---------^
-	//          field offset 0xD8          ARGB value (little-endian: B G R A)
-	// The 4-byte ARGB value starts at pattern offset +6.
-	const addr = Exe.FindHex("C7 ?? D8 00 00 00 00 00 00 66");
-	if (addr < 0)
-		throw Error("Chat background color pattern not found");
+	$$(_, 1.1, `Find the main chat background colour`)
+	const ctorAddr = Exe.FindHex("C7 ?? D8 00 00 00 00 00 00 66");
+	if (ctorAddr < 0) throw Error("Main chat background pattern not found");
+	const CTOR_ARGB_OFF = 6;
 
-	const ARGB_OFF = 6; // offset of the 4-byte ARGB value within the pattern
+	$$(_, 1.2, `Find the active-tab colour`)
+	const tabAddr = Exe.FindHex(
+		"3B 9E 14 01 00 00" + " B9 00 00 00 66" + " B8 00 00 00 99" + " 0F 44 C1");
+	if (tabAddr < 0) throw Error("Main chat active-tab pattern not found");
+	const TAB_ARGB_OFF = 7;
 
-	if (_ === "OpaqueChatBg")
-	{
-		$$(_, 2.1, `Set to fully opaque black: ARGB = 0xFF000000`)
-		// Little-endian byte order: B=00 G=00 R=00 A=FF
-		Exe.SetHex(addr + ARGB_OFF, "00 00 00 FF");
-	}
-	else
-	{
-		$$(_, 2.1, `Get the desired opacity (alpha) from the user`)
-		const alphaVar = "$chatBgAlpha";
-		const alpha = Exe.GetUserInput(
-			alphaVar, D_Uint8,
-			"Chat Background Opacity",
-			"Enter opacity (0 = fully transparent, 255 = fully opaque)",
-			0xFF,
-			{ min: 0, max: 255 }
-		);
-		if (alpha === false)
-			Cancel("Opacity", 255);
+	$$(_, 2.1, `Ask for the opacity`)
+	// WARP returns false when a value is left unchanged from its default; we treat
+	// that as "keep the default" instead of cancelling the whole patch.
+	const alphaIn = Exe.GetUserInput("$mainChatAlpha", D_Uint8,
+		"Main Chat Opacity", "Enter opacity (0 = transparent, 255 = opaque). Leave as-is to keep default.",
+		0x66, { min: 0, max: 255 });
+	const alpha = (alphaIn === false) ? 0x66 : alphaIn;
 
-		$$(_, 2.2, `Get the desired RGB color from the user`)
-		const colorVar = "$chatBgColor";
-		const color = Exe.GetUserInput(
-			colorVar, D_Color,
-			"Chat Background Color",
-			"Select the background color",
-			0x000000,
-			ROC.ClrSettings
-		);
-		if (color === false)
-			Cancel("Color", "#000000");
+	$$(_, 2.2, `Ask for the colour`)
+	// Leaving the picker on the default (#000000) keeps black.
+	const colorIn = Exe.GetUserInput("$mainChatColor", D_Color,
+		"Main Chat Background Colour", "Select the main chat colour",
+		0x000000, ROC.ClrSettings);
+	const color = (colorIn === false) ? 0x000000 : colorIn;
 
-		$$(_, 2.3, `Combine alpha + RGB and write as little-endian ARGB DWORD`)
-		// D_Color returns 0xRRGGBB; memory layout for ARGB little-endian is B G R A
-		const r = (color >> 16) & 0xFF;
-		const g = (color >>  8) & 0xFF;
-		const b =  color        & 0xFF;
-		const hx = [b, g, r, alpha]
-			.map(v => v.toString(16).toUpperCase().padStart(2, "0"))
-			.join(" ");
-		Exe.SetHex(addr + ARGB_OFF, hx);
-	}
+	$$(_, 2.3, `Apply the colour to the background and the active tab`)
+	// The colour picker returns the value as B-G-R; the client stores it as
+	// blue, green, red, alpha (in that byte order), so reorder before writing.
+	const r =  color        & 0xFF;
+	const g = (color >>  8) & 0xFF;
+	const b = (color >> 16) & 0xFF;
+	const hx = [b, g, r, alpha]
+		.map(v => v.toString(16).toUpperCase().padStart(2, "0")).join(" ");
+
+	Exe.SetHex(ctorAddr + CTOR_ARGB_OFF, hx); // background
+	Exe.SetHex(tabAddr  + TAB_ARGB_OFF,  hx); // active tab
 
 	return true;
 };
 
-OpaqueChatBg        = ChatBgOpacity;
-CustomChatBgOpacity = ChatBgOpacity;
+//=========================================================================
+// Detached chat windows
+//=========================================================================
+ChatBgDetached = function(_)
+{
+	$$(_, 1.1, `Find the detached window border colour`)
+	const outerAddr = Exe.FindHex(
+		"8B 86 EC 00 00 00" + " 68 00 00 00 66" + " FF B6 E8 00 00 00");
+	if (outerAddr < 0) throw Error("Detached window border pattern not found");
+	const OUTER_ARGB_OFF = 7;
+
+	$$(_, 1.2, `Find the detached window background colour`)
+	const subAddr = Exe.FindHex(
+		"C7 86 D4 00 00 00 00 00 00 66" + " 89 86 C4 00 00 00");
+	if (subAddr < 0) throw Error("Detached window background pattern not found");
+	const SUB_ARGB_OFF = 6;
+
+	$$(_, 2.1, `Ask for the opacity`)
+	// WARP returns false when a value is left unchanged from its default; we treat
+	// that as "keep the default" instead of cancelling the whole patch.
+	const alphaIn = Exe.GetUserInput("$detachedChatAlpha", D_Uint8,
+		"Detached Chat Opacity", "Enter opacity (0 = transparent, 255 = opaque). Leave as-is to keep default.",
+		0x66, { min: 0, max: 255 });
+	const alpha = (alphaIn === false) ? 0x66 : alphaIn;
+
+	$$(_, 2.2, `Ask for the colour`)
+	// Leaving the picker on the default (#000000) keeps black.
+	const colorIn = Exe.GetUserInput("$detachedChatColor", D_Color,
+		"Detached Chat Background Colour", "Select the detached chat colour",
+		0x000000, ROC.ClrSettings);
+	const color = (colorIn === false) ? 0x000000 : colorIn;
+
+	$$(_, 2.3, `Apply the colour to the border and the background`)
+	// The colour picker returns the value as B-G-R; the client stores it as
+	// blue, green, red, alpha (in that byte order), so reorder before writing.
+	const r =  color        & 0xFF;
+	const g = (color >>  8) & 0xFF;
+	const b = (color >> 16) & 0xFF;
+	const hx = [b, g, r, alpha]
+		.map(v => v.toString(16).toUpperCase().padStart(2, "0")).join(" ");
+
+	Exe.SetHex(outerAddr + OUTER_ARGB_OFF, hx); // border
+	Exe.SetHex(subAddr   + SUB_ARGB_OFF,   hx); // background
+
+	return true;
+};
+
+//=========================================================================
+// Whisper (1:1 private message) window
+//=========================================================================
+ChatBgWhisper = function(_)
+{
+	$$(_, 1.1, `Find the whisper window background colour`)
+	const frameAddr = Exe.FindHex(
+		"8B 46 14" + " 68 00 00 00 66" + " FF 76 18" + " 83 E8 02");
+	if (frameAddr < 0) throw Error("Whisper window background pattern not found");
+	const FRAME_ARGB_OFF = 4;
+
+	$$(_, 2.1, `Ask for the opacity`)
+	// WARP returns false when a value is left unchanged from its default; we treat
+	// that as "keep the default" instead of cancelling the whole patch.
+	const alphaIn = Exe.GetUserInput("$whisperChatAlpha", D_Uint8,
+		"Whisper Chat Opacity", "Enter opacity (0 = transparent, 255 = opaque). Leave as-is to keep default.",
+		0x66, { min: 0, max: 255 });
+	const alpha = (alphaIn === false) ? 0x66 : alphaIn;
+
+	$$(_, 2.2, `Ask for the colour`)
+	// Leaving the picker on the default (#000000) keeps black.
+	const colorIn = Exe.GetUserInput("$whisperChatColor", D_Color,
+		"Whisper Chat Background Colour", "Select the 1:1 whisper window colour",
+		0x000000, ROC.ClrSettings);
+	const color = (colorIn === false) ? 0x000000 : colorIn;
+
+	$$(_, 2.3, `Apply the colour to the whisper window background`)
+	// The colour picker returns the value as B-G-R; the client stores it as
+	// blue, green, red, alpha (in that byte order), so reorder before writing.
+	const r =  color        & 0xFF;
+	const g = (color >>  8) & 0xFF;
+	const b = (color >> 16) & 0xFF;
+	const hx = [b, g, r, alpha]
+		.map(v => v.toString(16).toUpperCase().padStart(2, "0")).join(" ");
+
+	Exe.SetHex(frameAddr + FRAME_ARGB_OFF, hx); // whisper window background
+
+	return true;
+};


### PR DESCRIPTION
Split the single chat background patch into three configurable patches and update UI metadata. Patches/UI.yml now exposes ChatBgMainPanel, ChatBgDetached and a new ChatBgWhisper entry (renamed previous entries and clarified titles/descriptions). Scripts/Patches/ChatBgOpacity.qjs was refactored: ChatBgOpacity was replaced by three functions that locate separate addresses, prompt for opacity and color (treating unchanged input as keep-default), reorder color bytes correctly, and apply values to background, active tab, border and whisper frames as appropriate. Also updated author and last-modified metadata. This allows independent color/opacity control for main chat, detached windows, and 1:1 whisper windows.