### PR TITLE
make HatEffects behave like SpecialEffects (buildings, walls and obst…

### DIFF
--- a/Patches/Special.yml
+++ b/Patches/Special.yml
@@ -67,6 +67,12 @@ CustomSpecials:
             recommend : no
             author : 4144
             desc : Removes the cap on displayed damage, healing, and other floating numbers. Without this, very large numbers get clamped to a maximum display value. Required for high-rate servers with large damage output.
+            
+        - AllHatEffectsWorldDepthOracle:
+            title : All HatEffects Screen-Size World Depth [QJS]
+            recommend : no
+            author : Louis T Steinhil
+            desc : "2025-07-16 build-specific global HatEffect depth patch, live validated on 2026-07-14. It preserves every original HatEffect STR resource, animation, actor attachment, metadata, teardown, screen-space position, apparent scale, and RHW. During only the two generic HatEffect render methods, vertices at/below actor-anchor Y retain a floor-safe four-quantum contact-biased depth; upper vertices reconstruct Y-up reciprocal depth using projection-matrix +0x10/+0x14 and convert it through 0x00554040. Native world STR NPCs remain unchanged."
 
 CustomSkills:
     title : SKILL CUSTOMIZATIONS

--- a/Scripts/Patches/AllHatEffectsWorldDepthOracle.qjs
+++ b/Scripts/Patches/AllHatEffectsWorldDepthOracle.qjs
@@ -1,0 +1,361 @@
+/**************************************************************************\
+*                                                                          *
+*   Copyright (C) 2026 Louis T Steinhil                                    *
+*                                                                          *
+*   This file is a part of WARP project (specific to RO clients)           *
+*                                                                          *
+*   WARP is free software: you can redistribute it and/or modify           *
+*   it under the terms of the GNU General Public License as published by   *
+*   the Free Software Foundation, either version 3 of the License, or      *
+*   (at your option) any later version.                                    *
+*                                                                          *
+*   This program is distributed in the hope that it will be useful,        *
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the           *
+*   GNU General Public License for more details.                           *
+*                                                                          *
+|**************************************************************************|
+*                                                                          *
+*   Author(s)     : Louis T Steinhil                                       *
+*   Created Date  : 2026-07-14                                             *
+*   Last Modified : 2026-07-14                                             *
+*                                                                          *
+*   Description   : Gives every HatEffect STR in the 2025-07-16 client     *
+*                   world-derived normalized vertex depth while preserving *
+*                   its original screen-space position and scale. Upper    *
+*                   vertices reconstruct Y-up world depth; floor-side      *
+*                   vertices retain a bounded camera-facing contact bias.  *
+*                                                                          *
+*   This build-specific oracle passed live occlusion and zoom validation.  *
+*                                                                          *
+\**************************************************************************/
+
+const AllHatEffectsWorldDepthOracleStatic = {
+	BuildDate: 20250716,
+	RenderCallNoArgVir: 0x00AFE41C,
+	RenderCallNoArgBytes: "E8 2F A3 FD FF",
+	RenderCallArgVir: 0x00AFE52B,
+	RenderCallArgBytes: "E8 20 A2 FD FF",
+	ScreenLayerLoopVir: 0x00AD8750,
+	AnchorProjectionVir: 0x00AD8D91,
+	AnchorProjectionBytes: "E8 1A B4 A7 FF",
+	ScreenNearDepthVir: 0x00AD93C5,
+	ScreenNearDepthBytes: "C7 42 EC C8 1C 02 38",
+	ScreenLayerBiasVir: 0x00AD9308,
+	ScreenLayerBiasBytes: "F3 0F 59 1D E4 6A FD 00",
+	DepthHookVir: 0x00AD93D4,
+	DepthHookBytes: "F3 0F 10 45 9C",
+	DepthStockContinueVir: 0x00AD93D9,
+	DepthConvertedContinueVir: 0x00AD93E2,
+	WorldDepthConvertVir: 0x00554040,
+	WorldDepthConvertCallVir: 0x00AD8B7D,
+	WorldDepthConvertCallBytes: "E8 BE B4 A7 FF",
+	RenderContextPtrVir: 0x012515F8,
+	NativeDepthQuantumVir: 0x00FD6AE4,
+	NativeAbsMaskVir: 0x00FD5D60,
+	ContactDepthBiasBits: 0x3827C5AC,
+	CaveSize: 0x120,
+	ContactBiasOffset: 0x04,
+	WrapperOffset: 0x08,
+	DepthBridgeOffset: 0x30,
+	WrapperSize: 32,
+	DepthBridgeSize: 228
+};
+
+AllHatEffectsWorldDepthOracleStatic.normalizeHex = function(hex)
+{
+	return (hex || "").replace(/\s+/g, " ").trim().toUpperCase();
+};
+
+AllHatEffectsWorldDepthOracleStatic.assertBytes = function(label, virAddr, expected)
+{
+	const phyAddr = Exe.Vir2Phy(virAddr, CODE);
+	if (phyAddr < 0)
+		throw Error(`AllHatEffectsWorldDepthOracle: ${label} is not mapped`);
+
+	const normalized = AllHatEffectsWorldDepthOracleStatic.normalizeHex(expected);
+	const size = normalized.split(" ").length;
+	const actual = AllHatEffectsWorldDepthOracleStatic.normalizeHex(
+		Exe.GetHex(phyAddr, size)
+	);
+	if (actual !== normalized)
+		throw Error(
+			`AllHatEffectsWorldDepthOracle: ${label} mismatch, got ${actual}`
+		);
+	return phyAddr;
+};
+
+AllHatEffectsWorldDepthOracleStatic.byteCount = function(hex)
+{
+	const compact = (hex || "").replace(/\s+/g, "");
+	if ((compact.length & 1) !== 0)
+		throw Error("AllHatEffectsWorldDepthOracle: odd generated hex length");
+	return compact.length / 2;
+};
+
+AllHatEffectsWorldDepthOracleStatic.rel32 = function(opcode, targetVir, sourceVir)
+{
+	return opcode + (targetVir - (sourceVir + 5)).toHex(4);
+};
+
+AllHatEffectsWorldDepthOracleStatic.rel8 = function(opcode, targetVir, sourceVir)
+{
+	const relative = targetVir - (sourceVir + 2);
+	if (relative < -128 || relative > 127)
+		throw Error(`AllHatEffectsWorldDepthOracle: rel8 out of range ${relative}`);
+	return opcode + (relative & 0xFF).toHex(1);
+};
+
+AllHatEffectsWorldDepthOracle = function(_)
+{
+	const state = AllHatEffectsWorldDepthOracleStatic;
+	if (Exe.BuildDate !== state.BuildDate)
+		throw Error("AllHatEffectsWorldDepthOracle supports only the 2025-07-16 client");
+
+	$$(_, 1, `Verify HatEffect render calls and the screen-STR depth path`);
+	const renderCallNoArgPhy = state.assertBytes(
+		"HatEffect no-argument render call",
+		state.RenderCallNoArgVir,
+		state.RenderCallNoArgBytes
+	);
+	const renderCallArgPhy = state.assertBytes(
+		"HatEffect argument render call",
+		state.RenderCallArgVir,
+		state.RenderCallArgBytes
+	);
+	state.assertBytes(
+		"screen-STR anchor projection",
+		state.AnchorProjectionVir,
+		state.AnchorProjectionBytes
+	);
+	state.assertBytes(
+		"screen-STR constant near depth",
+		state.ScreenNearDepthVir,
+		state.ScreenNearDepthBytes
+	);
+	state.assertBytes(
+		"screen-STR native layer-depth quantum",
+		state.ScreenLayerBiasVir,
+		state.ScreenLayerBiasBytes
+	);
+	const depthHookPhy = state.assertBytes(
+		"screen-STR reciprocal-depth load",
+		state.DepthHookVir,
+		state.DepthHookBytes
+	);
+	state.assertBytes(
+		"native normalized-depth conversion call",
+		state.WorldDepthConvertCallVir,
+		state.WorldDepthConvertCallBytes
+	);
+
+	$$(_, 2, `Build the HatEffect render scope and normalized-depth bridge`);
+	const [cavePhy, caveVir] = Exe.Allocate(state.CaveSize, 0x10);
+	const flagPhy = cavePhy;
+	const flagVir = caveVir;
+	const contactBiasPhy = cavePhy + state.ContactBiasOffset;
+	const contactBiasVir = caveVir + state.ContactBiasOffset;
+	const wrapperPhy = cavePhy + state.WrapperOffset;
+	const wrapperVir = caveVir + state.WrapperOffset;
+	const depthBridgePhy = cavePhy + state.DepthBridgeOffset;
+	const depthBridgeVir = caveVir + state.DepthBridgeOffset;
+
+	Exe.SetUint32(flagPhy, 0);
+	Exe.SetUint32(contactBiasPhy, state.ContactDepthBiasBits);
+
+	// The wrapper scopes the global depth hook to the two generic HatEffect
+	// render methods. The original screen-space STR loop still owns position,
+	// size, animation, texture, UV, color, blend state, and submission.
+	const wrapperCode =
+		"C7 05 " + flagVir.toHex(4) + " 01 00 00 00 " +
+		"FF 74 24 04 " +
+		state.rel32("E8", state.ScreenLayerLoopVir, wrapperVir + 14) +
+		"C7 05 " + flagVir.toHex(4) + " 00 00 00 00 " +
+		"C2 04 00";
+	const wrapperSize = state.byteCount(wrapperCode);
+	if (wrapperSize !== state.WrapperSize)
+		throw Error(`AllHatEffectsWorldDepthOracle: wrapper size ${wrapperSize}`);
+	Exe.SetHex(wrapperPhy, state.normalizeHex(wrapperCode));
+
+	// AD8C40 already obtains the actor projection from 005541B0. Keep its stock
+	// layer-biased RHW at vertex +0C. For vertex Z, pixels at/below the projected
+	// actor anchor retain a four-quantum contact-biased anchor plane, preventing
+	// floor intersection and shallow wall contact from consuming the sprite.
+	// Upper pixels reconstruct reciprocal depth along Ragnarok's Y-up axis:
+	//
+	//   rhw' = rhw * (m5*(y-cy) - m4*sy) /
+	//                (m5*(anchorY-cy) - m4*sy)
+	//
+	// This is the algebraic inverse of the native 005541B0 Y projection. A
+	// four-native-quantum contact tolerance is tiny relative to the stock
+	// always-on-top Z, but lets attached visuals survive touching geometry.
+	const depthBridgeHead =
+		"83 3D " + flagVir.toHex(4) + " 00 " +
+		"75 0A " +
+		"F3 0F 10 45 9C " +
+		state.rel32("E9", state.DepthStockContinueVir, depthBridgeVir + 14) +
+		"F3 0F 10 45 9C " +
+		"F3 0F 5C C3 " +
+		"F3 0F 11 42 F0 " +
+		"83 EC 14 " +
+		"F3 0F 11 4C 24 04 " +
+		"F3 0F 11 64 24 08 " +
+		"F3 0F 11 6C 24 0C " +
+		"F3 0F 11 74 24 10 " +
+		"F3 0F 10 45 9C " +
+		"F3 0F 58 05 " + contactBiasVir.toHex(4) + " " +
+		"F3 0F 10 62 E8 " +
+		"0F 2F 65 C4 ";
+	// The projection matrix must be reloaded from stable argument [EBP+10].
+	// Local [EBP-38] initially mirrors it but is reused before the vertex loop.
+	const uprightDepthHead =
+		"A1 " + state.RenderContextPtrVir.toHex(4) + " " +
+		"66 0F 6E 68 24 " +
+		"0F 5B ED " +
+		"F3 0F 5C E5 " +
+		"F3 0F 10 75 C4 " +
+		"F3 0F 5C F5 " +
+		"8B 4D 10 " +
+		"F3 0F 10 69 14 " +
+		"F3 0F 59 E5 " +
+		"F3 0F 59 F5 " +
+		"F3 0F 10 69 10 " +
+		"F3 0F 59 68 08 " +
+		"F3 0F 5C E5 " +
+		"F3 0F 5C F5 ";
+	const uprightDepthGuard =
+		"0F 28 EE " +
+		"0F 54 2D " + state.NativeAbsMaskVir.toHex(4) + " " +
+		"0F 2F 2D " + state.NativeDepthQuantumVir.toHex(4) + " ";
+	const uprightDepthTail =
+		"F3 0F 5E E6 " +
+		"F3 0F 59 65 9C " +
+		"F3 0F 58 25 " + contactBiasVir.toHex(4) + " " +
+		"0F 28 C4 ";
+	const depthConvertVir = depthBridgeVir +
+		state.byteCount(depthBridgeHead) + 2 +
+		state.byteCount(uprightDepthHead) +
+		state.byteCount(uprightDepthGuard) + 2 +
+		state.byteCount(uprightDepthTail);
+	const depthBridgeBeforeCall =
+		depthBridgeHead +
+		state.rel8(
+			"73",
+			depthConvertVir,
+			depthBridgeVir + state.byteCount(depthBridgeHead)
+		) +
+		uprightDepthHead +
+		uprightDepthGuard +
+		state.rel8(
+			"76",
+			depthConvertVir,
+			depthBridgeVir + state.byteCount(depthBridgeHead) + 2 +
+				state.byteCount(uprightDepthHead) +
+				state.byteCount(uprightDepthGuard)
+		) +
+		uprightDepthTail +
+		"F3 0F 11 04 24 ";
+	const depthConvertCallVir = depthBridgeVir +
+		state.byteCount(depthBridgeBeforeCall);
+	const depthBridgeAfterCall =
+		"F3 0F 10 4C 24 04 " +
+		"F3 0F 10 64 24 08 " +
+		"F3 0F 10 6C 24 0C " +
+		"F3 0F 10 74 24 10 " +
+		"D9 5A EC " +
+		"83 C4 14 ";
+	const depthBridgeBeforeReturn =
+		depthBridgeBeforeCall +
+		state.rel32("E8", state.WorldDepthConvertVir, depthConvertCallVir) +
+		depthBridgeAfterCall;
+	const depthBridgeCode =
+		depthBridgeBeforeReturn +
+		state.rel32(
+			"E9",
+			state.DepthConvertedContinueVir,
+			depthBridgeVir + state.byteCount(depthBridgeBeforeReturn)
+		);
+	const depthBridgeSize = state.byteCount(depthBridgeCode);
+	if (depthBridgeSize !== state.DepthBridgeSize)
+		throw Error(`AllHatEffectsWorldDepthOracle: depth bridge size ${depthBridgeSize}`);
+	Exe.SetHex(depthBridgePhy, state.normalizeHex(depthBridgeCode));
+
+	$$(_, 3, `Activate HatEffect-scoped depth conversion`);
+	Exe.SetCALL(renderCallNoArgPhy, wrapperVir, 0);
+	Exe.SetCALL(renderCallArgPhy, wrapperVir, 0);
+	Exe.SetJMP(depthHookPhy, depthBridgeVir, 0);
+
+	if (typeof PatchDiagnostics !== "undefined" && PatchDiagnostics &&
+		typeof PatchDiagnostics.add === "function")
+	{
+		PatchDiagnostics.add("AllHatEffectsWorldDepthOracle.Static", {
+			renderCallNoArgVir: state.RenderCallNoArgVir,
+			renderCallArgVir: state.RenderCallArgVir,
+			screenLayerLoopVir: state.ScreenLayerLoopVir,
+			anchorProjectionVir: state.AnchorProjectionVir,
+			screenNearDepthVir: state.ScreenNearDepthVir,
+			renderContextPtrVir: state.RenderContextPtrVir,
+			nativeDepthQuantumVir: state.NativeDepthQuantumVir,
+			contactBiasVir,
+			depthHookVir: state.DepthHookVir,
+			flagVir,
+			wrapperVir,
+			depthBridgeVir
+		});
+	}
+
+	return true;
+};
+
+AllHatEffectsWorldDepthOracle.validate = function()
+{
+	const state = AllHatEffectsWorldDepthOracleStatic;
+	if (Exe.BuildDate !== state.BuildDate)
+		return false;
+
+	try
+	{
+		state.assertBytes(
+			"HatEffect no-argument render call",
+			state.RenderCallNoArgVir,
+			state.RenderCallNoArgBytes
+		);
+		state.assertBytes(
+			"HatEffect argument render call",
+			state.RenderCallArgVir,
+			state.RenderCallArgBytes
+		);
+		state.assertBytes(
+			"screen-STR anchor projection",
+			state.AnchorProjectionVir,
+			state.AnchorProjectionBytes
+		);
+		state.assertBytes(
+			"screen-STR constant near depth",
+			state.ScreenNearDepthVir,
+			state.ScreenNearDepthBytes
+		);
+		state.assertBytes(
+			"screen-STR native layer-depth quantum",
+			state.ScreenLayerBiasVir,
+			state.ScreenLayerBiasBytes
+		);
+		state.assertBytes(
+			"screen-STR reciprocal-depth load",
+			state.DepthHookVir,
+			state.DepthHookBytes
+		);
+		state.assertBytes(
+			"native normalized-depth conversion call",
+			state.WorldDepthConvertCallVir,
+			state.WorldDepthConvertCallBytes
+		);
+	}
+	catch (error)
+	{
+		console.warn(String(error));
+		return false;
+	}
+
+	return true;
+};


### PR DESCRIPTION
…acles occlusion)

Gives every HatEffect STR in the 2025-07-16 client world-derived normalized vertex depth while preserving its original screen-space position and scale. Upper vertices reconstruct Y-up world depth; floor-side vertices retain a bounded camera-facing contact bias.

[https://www.youtube.com/watch?v=D5Su1Rl3Jtw](url)