### PR TITLE
Fix/incrhairs stage2 open off by one

### DIFF
--- a/Scripts/Patches/IncrHairs.qjs
+++ b/Scripts/Patches/IncrHairs.qjs
@@ -84,7 +84,7 @@ IncrHairs.stage2_open = _ =>
 		const hookCode =
 			" A1" + site.tableGlobal.toHex(4)  // MOV EAX, [table_global]  (5 bytes)
 		+	" 83 F9" + TABLE_LIMIT.toHex(1)    // CMP ECX, 43             (3 bytes)
-		+	" 7E 03"                            // JLE +3 → skip clamp    (2 bytes)
+		+	" 7C 03"                            // JL +3 → skip clamp ; must be JL, not JLE: the table has 43 entries (0-42), so index 43 must be clamped too (2 bytes)
 		+	" 33 C9"                            // XOR ECX, ECX            (2 bytes)
 		+	" 41"                               // INC ECX → ECX = 1      (1 byte)
 		+	" 8B 14 88"                         // MOV EDX, [EAX+ECX*4]   (3 bytes)


### PR DESCRIPTION
## Summary

`IncrHairs.stage2_open` (the open-source stage2 replacement for 2020+ clients) has an off-by-one in its bounds check: the generated hook stub uses **`JLE 43`** (`7E`) where it must use **`JL 43`** (`7C`). The hair tables it guards hold exactly **43 entries (indices 0–42)**, so `TABLE_LIMIT` (0x2B = 43) is the table *size*, not the last valid index — the stub's own comment ("43 entries in hair table (indices 0-42)") already states this. With `JLE`, index 43 slips through the clamp and the stub reads **one dword past the end of the table**.

```asm
MOV  EAX, [table_global]
CMP  ECX, 43
JLE  load          ; BUG: 43 passes — must be JL
XOR  ECX, ECX
INC  ECX           ; >43 → clamped to 1
load:
MOV  EDX, [EAX+ECX*4]   ; with ECX=43: out-of-bounds read
```

One byte per stub fixes it: `7E` → `7C`. Hair style 43 is now clamped to index 1, exactly like 44+ already was.

## Consequence

The dword read past the table is whatever the heap happens to hold next to the vector. It is then treated as a `char*` and fed to an inlined `strlen`:

- if that garbage value points into **mapped** memory, `strlen` walks garbage until a zero byte — the client silently builds a corrupt sprite path and keeps running;
- if it points into **unmapped** memory, the client dies with an access violation (`0xC0000005`).

## Why it looks random (and why it was hard to pin down)

Two properties combine to make this bug extremely misleading:

**1. The outcome is decided by heap layout, not by code.** The ghost dword next to the table depends on the process's entire allocation history, so it changes between launches (and can change mid-session when the neighboring block is reused). Verified live on two sessions of the same client: the ghost cell held `0x02db4401` (unmapped → crash at the inlined `strlen`) in one session and `0x00808009` (readable, first byte `0x00` → empty string, fully silent) in the next. Same hair, same headgear, opposite outcomes. Within one session results look consistent, so testers naturally attribute the crash to whatever variable they changed *between* sessions (a specific view ID, char-select vs in-game, etc.) — all red herrings.

**2. Only the hat path is affected — bare heads are fine.** Stage1 patches the head sprite/palette builders with the itoa approach, so hair 43+ *alone* renders correctly and never touches the tables. The stage2_open stubs live in the headgear path builder, which starts with `if (view == 0) return "";` — it only runs when a headgear is actually equipped. So the failure needs the conjunction **hair == 43 AND any equipped headgear**, while:

- hair 43 with no hat: never crashes (stage1/itoa path only);
- hair 0–42 with any hat: never crashes (valid index);
- hair 44+ with any hat: never crashes (clamped to 1);
- **hair exactly 43 with any hat: undefined behavior, crash decided by a heap coin flip.**

The trigger (equipping a headgear) and the defect (the hair index) live in two different variables, and the outcome is randomized on top — diagnosed by freezing the AV in a debugger at the inlined `strlen` and confirming ECX equals the dword stored at `table._Myfirst + 43*4`, one past `_Mylast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
