### PR TITLE
Add patch: play the sound on an animation's first frame

### DIFF
--- a/Patches/Sound.yml
+++ b/Patches/Sound.yml
@@ -49,4 +49,10 @@ CustomSound:
             recommend : no
             author : Andrei Karas (4144) , X-EcutiOnner
             desc : Disables background music loading from mp3NameTable.txt, preventing BGM from playing on any map. Use if you want a completely silent game or handle music through external means.
+        
+        - PlayFirstFrameSounds:
+            title : Play the sound placed on the first frame of an animation
+            recommend : yes
+            author : Stingor
+            desc : The client never plays a sound event placed on frame 0 of an animation that has just REPLACED another one. On an action change it rewinds its "last sounded frame" cursor to 0 and then plays the frames after it, so frame 0 is skipped. Looping animations and actions replayed as-is are unaffected -- which is why hurt and attack sounds are already heard from the second blow onwards, only the first one missing. Death animations always follow another action and are never replayed, so their frame-0 sound is never heard at all: over the 2103 monster sprites of a 2025 kRO data.grf that is 47 silent death sounds, among them Doppelganger and the twelve Bio Lab clones, Baphomet, Osiris, Thanatos, Pupa, Orc Warrior, Obeaune and Elder Willow. This patch rewinds the cursor to -1 instead, so the loop starts at frame 0 and those sounds are heard. (Warning: doppleganger_die.wav is a bit annoying :D)
 

--- a/Scripts/Patches/PlayFirstFrameSounds.qjs
+++ b/Scripts/Patches/PlayFirstFrameSounds.qjs
@@ -1,0 +1,93 @@
+/**************************************************************************\
+*                                                                          *
+*   Copyright (C) 2026                                                     *
+*                                                                          *
+*   This file is a part of WARP project (specific to RO clients)           *
+*                                                                          *
+*   WARP is free software: you can redistribute it and/or modify           *
+*   it under the terms of the GNU General Public License as published by   *
+*   the Free Software Foundation, either version 3 of the License, or      *
+*   (at your option) any later version.                                    *
+*                                                                          *
+|**************************************************************************|
+*                                                                          *
+*   Author(s)     : Stingor empowered by Claude                            *
+*   Created Date  : 2026-09-09                                             *
+*   Last Modified : 2026-09-09                                             *
+*                                                                          *
+\**************************************************************************/
+
+///
+/// \brief Plays the sound event attached to the FIRST frame of an animation.
+///
+///        Every .act frame can carry a sound event, and on each tick the client
+///        walks the frames it has just crossed and plays the sounds it finds.
+///        On an action change it rewinds its "last sounded frame" cursor to 0,
+///        then plays frames cursor+1 .. current -- so frame 0 is skipped:
+///
+///            MOV DWORD PTR [ESI+44],0   ; last sounded frame <- 0
+///            XOR EDI,EDI
+///            ...
+///            CMP EDI,EBX                ; EBX = current frame
+///            JGE (nothing to play)
+///            INC EDI                    ; the loop starts at last+1, i.e. 1
+///
+///        Frame 0 is only ever reached through the other branch, the one where
+///        the cursor sits FURTHER along than the current frame. Two things take
+///        it there: an animation that LOOPS (idle, walk), and an action REPLAYED
+///        AS-IS -- ChildSprite_SetAction (0x00C55DA0) rewrites the action and
+///        resets the frame to 0 without touching the cursor, so a monster hit
+///        again while already playing its hurt animation walks over frame 0 and
+///        does sound it.
+///
+///        What stays silent is therefore not "every action that does not loop",
+///        but the first frame of an action that has just REPLACED another one.
+///        In practice: hurt and attack sounds are already heard from the second
+///        blow onwards and only the very first is missing, which nobody notices.
+///        Death sounds are never heard at all -- a death action always follows
+///        another one and is never replayed.
+///
+///        Counted over the 2103 monster sprites of a 2025 kRO data.grf, 47
+///        sprites carry their death sound on that first frame and so never make
+///        it heard: Doppelganger and the twelve Bio Lab clones (Seyren, Eremes,
+///        Katrinn, ...), whose die action is a single frame carrying
+///        doppleganger_die.wav, plus Baphomet, Osiris, Thanatos, Pupa, Orc
+///        Warrior, Obeaune and Elder Willow. (95 further sprites put a sound on
+///        the first frame of their hurt animation and 11 on their attack; those
+///        are already audible, and the patch only adds their first blow.)
+///
+///        This patch rewinds the cursor to -1 instead of 0, so the loop starts
+///        at frame 0 and the sprite data is honoured. Nothing else changes. The
+///        wrap-around branch is untouched, so idle and walk sound exactly as
+///        they did, and no sound can play twice -- as before, the cursor is
+///        written back to the current frame at the end of every call, so a
+///        frame is never walked over more than once.
+///
+PlayFirstFrameSounds = function(_)
+{
+	$$(_, 1, `Find the actor frame sound player`)
+	// MOV ESI,ECX | MOV EDI,[ESI+44] | LEA EDX,[ESI+40] | MOV EBX,[ESI+3C] |
+	// MOV EAX,[EDX] | CMP EDI,EBX
+	// Three field loads in a row -- last sounded frame, remembered action,
+	// current frame -- followed by the comparison that drives the whole
+	// function. That is enough to name it: a single match in the executable.
+	const fnAddr = Exe.FindHex("8B F1 8B 7E 44 8D 56 40 8B 5E 3C 8B 02 3B FB");
+	if (fnAddr < 0)
+		throw Error("Frame sound player not found");
+
+	$$(_, 2, `Find the cursor rewind performed on an action change`)
+	// MOV DWORD PTR [ESI+44],0 | XOR EDI,EDI
+	// Reached only when the current action differs from the remembered one.
+	const rewindAddr = Exe.FindHex("C7 46 44 00 00 00 00 33 FF", fnAddr, fnAddr + 0x40);
+	if (rewindAddr < 0)
+		throw Error("Frame cursor rewind not found");
+
+	$$(_, 3, `Rewind to -1 so the loop starts at frame 0`)
+	// OR DWORD PTR [ESI+44],-1 | OR EDI,-1 | NOP | NOP
+	// Nine bytes in, nine bytes out, so nothing downstream moves. OR writes the
+	// flags where the original XOR did; harmless, since the next branch is a CMP
+	// two instructions further down.
+	Exe.SetHex(rewindAddr, "83 4E 44 FF 83 CF FF 90 90");
+
+	return true;
+};


### PR DESCRIPTION
Sprite animations can carry a sound on each of their frames, and the client plays them as the animation runs -- except for the very first frame, which it always skips when an animation starts. Looping animations get away with it: idle and walk eventually come back round to their first frame, so it is heard. Animations that play once and stop -- attack, hurt, die -- never come back round, so whatever sound sits on their first frame is simply never heard.

That is not a rare corner. Across the 2103 monster sprites of a 2025 kRO data.grf it silences 47 death sounds, 95 hit sounds and 11 attack sounds. The best known victims are the Bio Lab monsters: Seyren, Eremes, Katrinn and the rest have a death animation of a single frame carrying doppleganger_die.wav, so they die in complete silence -- and so does Doppelganger himself, who shares that sound.

The patch makes the client start at the first frame instead of the second. Nothing else changes: looping animations already played their first frame and still do, and no sound can be heard twice.

Monsters that regain a sound (ids read from a pre-renewal mob_db):

  doppleganger_die.wav
      Doppelganger 1046, 1731, 1966, 2098, 2276
      Seyren Windsor 1634, 1640, 1646, 1799, 1805, 1895, 2112
      Eremes Guile 1635, 1641, 1647, 1800, 1806, 2113
      Howard Alt-Eisen 1636, 1642, 1648, 1801, 1807, 2111
      Margaretha Sorin 1637, 1643, 1649, 1802, 1808
      Cecil Damon 1638, 1644, 1650, 1723, 1803, 1809, 2667, 3170
      Kathryne Keyron 1639, 1645, 1651, 1804, 1810, 1896
      Egnigem Cenia 1652, 1658, 1967, 2274, 2275
      Wickebine Tres 1653, 1659, 2272, 2273
      Armeyer Dinze 1654, 1660, 2264, 2265
      Errende Ebecee 1655, 1661, 2266, 2267
      Kavach Icarus 1656, 1662, 2268, 2269
      Laurell Weinder 1657, 1663, 2270, 2271, 2692
  baphomet_die.wav      Baphomet 1039, 1848, 1897, 2100, Unsealed 1929
  baphomet__die.wav     Baphomet 1399
  ork_warrior_die1.wav  Orc Warrior 1023, 2722, Orc Archer 1189, 1473, 1982,
                        Smoking Orc 1235
  elder_wilow_die.wav   Elder Willow 1033, 1574, 2839, 2840, 2924
  worm_tail_die.wav     Wormtail 1024, 2610, Stem Worm 1215, 1440, 2641
  obeaune_damage.wav    Obeaune 1044, 1425, 1970
  obeaune_die.wav       Iara 2069, 2795
  osiris_die.wav        Osiris 1038, 1849, 2096
  pupa_die.wav          Pupa 1008, 1230, Thief Bug Egg 1048
  orc_baby_damage.wav   Orc Baby 1686, Strange Baby Orc 2451
  creamy_die.wav        Creamy Fear 1293
  thanatos_damage.wav   Memory of Thanatos 1708
  wolf_die.wav          Vagabond Wolf 1092

On a few of them -- Obeaune, Orc Baby, Thanatos -- the sprite author put a _damage sound on the death animation. The patch plays what the data says, so that is what will be heard.